### PR TITLE
:memo: Add notice about new API authorization flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ These samples demonstrate how to add authentication to an Angular application wi
 
 The samples show how to integrate Auth0 using [Auth0Lock](https://github.com/auth0/lock) >= 10.9.0 and [auth0.js](https://github.com/auth0/auth0.js) >= 8.0.0.
 
+> Note: If you are receiving `Unsupported response type: id_token token` errors when using these samples please make sure that your account has been updated to support the new API Authorization flows. For details please see: [Configure your tenant for the new API Authorization flows](https://auth0.com/docs/api-auth/tutorials/configuring-tenant-for-api-auth)
+
 ## What is Auth0?
 
 Auth0 helps you to:


### PR DESCRIPTION
This notice and an documentation link should help users
to fix problems when using sammples with accounts that have not
yet been migrated to new API authorization flows.

See my case:
auth0-samples/auth0-angular-samples#4

and support forum ticket:
https://auth0.com/forum/t/unsupported-response-type-token-id-token/4919

Thanks!