### PR TITLE
fix(00-HostedLogin): fix tests

### DIFF
--- a/00-Hosted-Login/src/app/app.component.spec.ts
+++ b/00-Hosted-Login/src/app/app.component.spec.ts
@@ -1,11 +1,21 @@
 /* tslint:disable:no-unused-variable */
 
 import { TestBed, async } from '@angular/core/testing';
+import { RouterModule, Router } from '@angular/router';
+import { APP_BASE_HREF } from '@angular/common';
 import { AppComponent } from './app.component';
+import { AuthService } from './auth/auth.service';
 
 describe('AppComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [
+        RouterModule.forRoot([])
+      ],
+      providers:[
+        { provide: AuthService, useValue: { handleAuthentication: () => {}, isAuthenticated: () => {} } },
+        { provide: APP_BASE_HREF, useValue: '/' }
+      ],
       declarations: [
         AppComponent
       ],
@@ -19,16 +29,4 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   }));
 
-  it(`should have as title 'app works!'`, async(() => {
-    let fixture = TestBed.createComponent(AppComponent);
-    let app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual('app works!');
-  }));
-
-  it('should render title in a h1 tag', async(() => {
-    let fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    let compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('app works!');
-  }));
 });

--- a/00-Hosted-Login/src/app/auth/auth.service.spec.ts
+++ b/00-Hosted-Login/src/app/auth/auth.service.spec.ts
@@ -1,12 +1,17 @@
 /* tslint:disable:no-unused-variable */
 
 import { TestBed, async, inject } from '@angular/core/testing';
+import { Router } from '@angular/router';
 import { AuthService } from './auth.service';
 
 describe('AuthService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [AuthService]
+      providers: [
+        AuthService,
+        {
+          provide: Router, useValue: { navigate: () => {} }
+        }]
     });
   });
 

--- a/00-Hosted-Login/src/app/home/home.component.spec.ts
+++ b/00-Hosted-Login/src/app/home/home.component.spec.ts
@@ -4,6 +4,7 @@ import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
 
 import { HomeComponent } from './home.component';
+import { AuthService } from './../auth/auth.service';
 
 describe('HomeComponent', () => {
   let component: HomeComponent;
@@ -11,7 +12,10 @@ describe('HomeComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ HomeComponent ]
+      declarations: [ HomeComponent ],
+      providers: [
+        { provide: AuthService, useValue: { isAuthenticated: () => false }}
+      ]
     })
     .compileComponents();
   }));

--- a/00-Hosted-Login/src/test.ts
+++ b/00-Hosted-Login/src/test.ts
@@ -1,5 +1,3 @@
-import './polyfills.ts';
-
 import 'zone.js/dist/long-stack-trace-zone';
 import 'zone.js/dist/proxy.js';
 import 'zone.js/dist/sync-test';


### PR DESCRIPTION
Fixes #19

This had several reasons of failing:

- polyfills.ts was executed twice when running `npm run test`
- multiple dependencies could not be resolved on a per test base
- invalid tests (angular-cli default tests were still there).

I'm not sure if you guys want to have tests. If not, I can drop this PR and remove them instead. But if tests are preferred, this should allow people to execute them. 