### PR TITLE
Fix token renewal by explicitly setting postMessageOrigin in renewAuth

### DIFF
--- a/05-Token-Renewal/README.md
+++ b/05-Token-Renewal/README.md
@@ -35,7 +35,7 @@ The application will be served at `http://localhost:4200`.
 
 ## Making It Live
 
-To make the silent authentication work on a live environment, you'll need to edit the two `localhost` urls in `silent.html` and the one `localhost` url you have in the `auth0-variables.ts` file.
+To make the silent authentication work on a live environment, you'll need to edit the two `localhost` urls in `silent.html` and `auth.service.ts` plus the one `localhost` url you have in the `auth0-variables.ts` file.
 
 ## Troubleshooting
 If you see an error on renewal saying `login_required`, that means you may be using the Auth0 dev keys for whichever social login you're testing. You'll need to add your own keys for this to work.

--- a/05-Token-Renewal/src/app/auth/auth.service.ts
+++ b/05-Token-Renewal/src/app/auth/auth.service.ts
@@ -87,7 +87,8 @@ export class AuthService {
     this.auth0.renewAuth({
       audience: AUTH_CONFIG.apiUrl,
       redirectUri: 'http://localhost:3001/silent',
-      usePostMessage: true
+      usePostMessage: true,
+      postMessageOrigin: 'http://localhost:3001'
     }, (err, result) => {
       if (err) {
         alert(`Could not get a new token using silent authentication (${err.error}).`);


### PR DESCRIPTION
This PR will have a corresponding one in the auth0/docs repo to also fix the issue in the sample snippets.