### PR TITLE
Change bootstrap dependency to version ^3.3.7

### DIFF
--- a/01-Login/package.json
+++ b/01-Login/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser-dynamic": "^5.2.6",
     "@angular/router": "^5.2.6",
     "auth0-js": "^9.4.1",
-    "bootstrap": "<=4.1.1",
+    "bootstrap": "^3.3.7",
     "core-js": "^2.4.1",
     "rxjs": "^5.5.6",
     "zone.js": "^0.8.20"

--- a/01-Login/package.json
+++ b/01-Login/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser-dynamic": "^5.2.6",
     "@angular/router": "^5.2.6",
     "auth0-js": "^9.4.1",
-    "bootstrap": "^4.0.0",
+    "bootstrap": "<=4.1.1",
     "core-js": "^2.4.1",
     "rxjs": "^5.5.6",
     "zone.js": "^0.8.20"


### PR DESCRIPTION
Fixes an issue where a change in an Angular CLI v1.7.2 dependency, `AutoPrefixer`, causes the error: 

> BrowserslistError: Unknown browser query `dead`

`@angular/cli@1.7.4` has a dependency on `autoprefixer@7.2.6` which has a dependency on `browserslist@2.11.3`. `browserslist` < 3.0 triggers the error when latest version of Bootstrap to date, `bootstrap@4.1.2`, is used. 

Change to `"bootstrap": "^3.3.7"` to match the `bootstrap` version of all other steps. 