### PR TITLE
Remove redundant 'Custom Domains'

### DIFF
--- a/01-Embedded-Login/README.md
+++ b/01-Embedded-Login/README.md
@@ -2,7 +2,7 @@
 
 This sample demonstrates how to add authentication to an Angular application using Auth0's Lock widget embedded in your application.
 
-Note that embedded login uses Cross Origin Authentication which [does not work well](https://auth0.com/docs/cross-origin-authentication#limitations-of-cross-origin-authentication) if you don't enable Custom Domains [Custom Domains](https://auth0.com/docs/custom-domains) which is a paid feature. 
+Note that embedded login uses Cross Origin Authentication which [does not work well](https://auth0.com/docs/cross-origin-authentication#limitations-of-cross-origin-authentication) if you don't enable [Custom Domains](https://auth0.com/docs/custom-domains) which is a paid feature. 
 
 The sample uses the Angular CLI.
 


### PR DESCRIPTION
The phrase 'Custom Domains' is repeated and feels out of place when reading the readme. 