### PR TITLE
Properly get token expiration

### DIFF
--- a/05-Token-Renewal/src/app/auth/auth.service.ts
+++ b/05-Token-Renewal/src/app/auth/auth.service.ts
@@ -37,6 +37,10 @@ export class AuthService {
     return this._idToken;
   }
 
+  get expiresAt(): number {
+    return this._expiresAt;
+  }
+
   public login(): void {
     this.auth0.authorize();
   }

--- a/05-Token-Renewal/src/app/home/home.component.ts
+++ b/05-Token-Renewal/src/app/home/home.component.ts
@@ -11,7 +11,7 @@ export class HomeComponent {
   constructor(public auth: AuthService) { }
 
   get expiresAt() {
-    return JSON.parse(window.localStorage.getItem('expires_at'));
+    return this.auth.expiresAt;
   }
 
 }


### PR DESCRIPTION
Get token expiration from `AuthService` property instead of localStorage.