### PR TITLE
Stop using localstorage to keep logged in state

### DIFF
--- a/01-Login/src/app/app.component.ts
+++ b/01-Login/src/app/app.component.ts
@@ -13,7 +13,7 @@ export class AppComponent implements OnInit {
   }
 
   ngOnInit() {
-    if (localStorage.getItem('isLoggedIn') === 'true') {
+    if (this.auth.isAuthenticated()) {
       this.auth.renewTokens();
     }
   }

--- a/01-Login/src/app/auth/auth.service.ts
+++ b/01-Login/src/app/auth/auth.service.ts
@@ -49,10 +49,8 @@ export class AuthService {
   }
 
   private localLogin(authResult): void {
-    // Set isLoggedIn flag in localStorage
-    localStorage.setItem('isLoggedIn', 'true');
     // Set the time that the access token will expire at
-    const expiresAt = (authResult.expiresIn * 1000) + new Date().getTime();
+    const expiresAt = (authResult.expiresIn * 1000) + Date.now();
     this._accessToken = authResult.accessToken;
     this._idToken = authResult.idToken;
     this._expiresAt = expiresAt;
@@ -74,8 +72,6 @@ export class AuthService {
     this._accessToken = '';
     this._idToken = '';
     this._expiresAt = 0;
-    // Remove isLoggedIn flag from localStorage
-    localStorage.removeItem('isLoggedIn');
     // Go back to the home route
     this.router.navigate(['/']);
   }
@@ -83,7 +79,7 @@ export class AuthService {
   public isAuthenticated(): boolean {
     // Check whether the current time is past the
     // access token's expiry time
-    return new Date().getTime() < this._expiresAt;
+    return this._accessToken && Date.now() < this._expiresAt;
   }
 
 }

--- a/02-User-Profile/src/app/app.component.ts
+++ b/02-User-Profile/src/app/app.component.ts
@@ -13,7 +13,7 @@ export class AppComponent implements OnInit {
   }
 
   ngOnInit() {
-    if (localStorage.getItem('isLoggedIn') === 'true') {
+    if (this.auth.isAuthenticated()) {
       this.auth.renewTokens();
     }
   }

--- a/02-User-Profile/src/app/auth/auth.service.ts
+++ b/02-User-Profile/src/app/auth/auth.service.ts
@@ -67,10 +67,8 @@ export class AuthService {
   }
 
   private localLogin(authResult): void {
-    // Set isLoggedIn flag in localStorage
-    localStorage.setItem('isLoggedIn', 'true');
     // Set the time that the access token will expire at
-    const expiresAt = (authResult.expiresIn * 1000) + new Date().getTime();
+    const expiresAt = (authResult.expiresIn * 1000) + Date.now();
     this._accessToken = authResult.accessToken;
     this._idToken = authResult.idToken;
     this._expiresAt = expiresAt;
@@ -92,8 +90,6 @@ export class AuthService {
     this._idToken = '';
     this._accessToken = '';
     this._expiresAt = 0;
-    // Remove isLoggedIn flag from localStorage
-    localStorage.removeItem('isLoggedIn');
     // Go back to the home route
     this.router.navigate(['/']);
   }
@@ -101,7 +97,7 @@ export class AuthService {
   public isAuthenticated(): boolean {
     // Check whether the current time is past the
     // access token's expiry time
-    return new Date().getTime() < this._expiresAt;
+    return this._accessToken && Date.now() < this._expiresAt;
   }
 
 }

--- a/03-Calling-an-API/src/app/app.component.ts
+++ b/03-Calling-an-API/src/app/app.component.ts
@@ -13,7 +13,7 @@ export class AppComponent implements OnInit {
   }
 
   ngOnInit() {
-    if (localStorage.getItem('isLoggedIn') === 'true') {
+    if (this.auth.isAuthenticated()) {
       this.auth.renewTokens();
     }
   }

--- a/03-Calling-an-API/src/app/auth/auth.service.ts
+++ b/03-Calling-an-API/src/app/auth/auth.service.ts
@@ -68,10 +68,8 @@ export class AuthService {
   }
 
   private localLogin(authResult): void {
-    // Set isLoggedIn flag in localStorage
-    localStorage.setItem('isLoggedIn', 'true');
     // Set the time that the access token will expire at
-    const expiresAt = (authResult.expiresIn * 1000) + new Date().getTime();
+    const expiresAt = (authResult.expiresIn * 1000) + Date.now();
     this._accessToken = authResult.accessToken;
     this._idToken = authResult.idToken;
     this._expiresAt = expiresAt;
@@ -93,8 +91,6 @@ export class AuthService {
     this._idToken = '';
     this._accessToken = '';
     this._expiresAt = 0;
-    // Remove isLoggedIn flag from localStorage
-    localStorage.removeItem('isLoggedIn');
     // Go back to the home route
     this.router.navigate(['/']);
   }
@@ -102,7 +98,7 @@ export class AuthService {
   public isAuthenticated(): boolean {
     // Check whether the current time is past the
     // access token's expiry time
-    return new Date().getTime() < this._expiresAt;
+    return this._accessToken && Date.now() < this._expiresAt;
   }
 
 }

--- a/04-Authorization/src/app/app.component.ts
+++ b/04-Authorization/src/app/app.component.ts
@@ -19,7 +19,7 @@ export class AppComponent  implements OnInit {
   }
 
   ngOnInit() {
-    if (localStorage.getItem('isLoggedIn') === 'true') {
+    if (this.auth.isAuthenticated()) {
       this.auth.renewTokens();
     }
   }

--- a/04-Authorization/src/app/auth/auth.service.ts
+++ b/04-Authorization/src/app/auth/auth.service.ts
@@ -71,10 +71,8 @@ export class AuthService {
   }
 
   private localLogin(authResult): void {
-    // Set isLoggedIn flag in localStorage
-    localStorage.setItem('isLoggedIn', 'true');
     // Set the time that the access token will expire at
-    const expiresAt = (authResult.expiresIn * 1000) + new Date().getTime();
+    const expiresAt = (authResult.expiresIn * 1000) + Date.now();
 
     // If there is a value on the `scope` param from the authResult,
     // use it to set scopes in the session for the user. Otherwise
@@ -104,8 +102,6 @@ export class AuthService {
     this._accessToken = '';
     this._expiresAt = 0;
     this._scopes = '';
-    // Remove isLoggedIn flag from localStorage
-    localStorage.removeItem('isLoggedIn');
     // Go back to the home route
     this.router.navigate(['/']);
   }
@@ -113,7 +109,7 @@ export class AuthService {
   public isAuthenticated(): boolean {
     // Check whether the current time is past the
     // access token's expiry time
-    return new Date().getTime() < this._expiresAt;
+    return this._accessToken && Date.now() < this._expiresAt;
   }
 
   public userHasScopes(scopes: Array<string>): boolean {

--- a/05-Token-Renewal/src/app/app.component.ts
+++ b/05-Token-Renewal/src/app/app.component.ts
@@ -14,7 +14,7 @@ export class AppComponent implements OnInit {
   }
 
   ngOnInit() {
-    if (localStorage.getItem('isLoggedIn') === 'true') {
+    if (this.auth.isAuthenticated()) {
       this.auth.renewTokens();
     }
   }

--- a/05-Token-Renewal/src/app/auth/auth.service.ts
+++ b/05-Token-Renewal/src/app/auth/auth.service.ts
@@ -73,8 +73,6 @@ export class AuthService {
   }
 
   private localLogin(authResult): void {
-    // Set isLoggedIn flag in localStorage
-    localStorage.setItem('isLoggedIn', 'true');
     // Set the time that the access token will expire at
     const expiresAt = (authResult.expiresIn * 1000) + Date.now();
     this._accessToken = authResult.accessToken;
@@ -89,8 +87,6 @@ export class AuthService {
     this._idToken = '';
     this._accessToken = '';
     this._expiresAt = 0;
-    // Remove isLoggedIn flag from localStorage
-    localStorage.removeItem('isLoggedIn');
     this.unscheduleRenewal();
     // Go back to the home route
     this.router.navigate(['/']);
@@ -110,7 +106,7 @@ export class AuthService {
   public isAuthenticated(): boolean {
     // Check whether the current time is past the
     // access token's expiry time
-    return Date.now() < this._expiresAt;
+    return this._accessToken && Date.now() < this._expiresAt;
   }
 
   public scheduleRenewal() {

--- a/06-Single-Sign-On/sso-app-one/src/app/auth/auth.service.ts
+++ b/06-Single-Sign-On/sso-app-one/src/app/auth/auth.service.ts
@@ -73,8 +73,7 @@ export class AuthService {
 
   private localLogin(authResult): void {
     // Set the time that the access token will expire at
-    const expiresAt = authResult.expiresIn * 1000 + new Date().getTime();
-    localStorage.setItem('isLoggedIn', 'true');
+    const expiresAt = authResult.expiresIn * 1000 + Date.now();
     this._accessToken = authResult.accessToken;
     this._idToken = authResult.idToken;
     this._expiresAt = expiresAt;
@@ -83,7 +82,6 @@ export class AuthService {
   }
 
   public logout(): void {
-    localStorage.removeItem('isLoggedIn');
     // Remove tokens and expiry time
     this._accessToken = '';
     this._idToken = '';
@@ -96,7 +94,7 @@ export class AuthService {
   public isAuthenticated(): boolean {
     // Check whether the current time is past the
     // access token's expiry time
-    return new Date().getTime() < this._expiresAt;
+    return this._accessToken && Date.now() < this._expiresAt;
   }
 
   public renewTokens() {

--- a/06-Single-Sign-On/sso-app-two/src/app/auth/auth.service.ts
+++ b/06-Single-Sign-On/sso-app-two/src/app/auth/auth.service.ts
@@ -73,8 +73,7 @@ export class AuthService {
 
   private localLogin(authResult): void {
     // Set the time that the access token will expire at
-    const expiresAt = authResult.expiresIn * 1000 + new Date().getTime();
-    localStorage.setItem('isLoggedIn', 'true');
+    const expiresAt = authResult.expiresIn * 1000 + Date.now();
     this._accessToken = authResult.accessToken;
     this._idToken = authResult.idToken;
     this._expiresAt = expiresAt;
@@ -83,7 +82,6 @@ export class AuthService {
   }
 
   public logout(): void {
-    localStorage.removeItem('isLoggedIn');
     // Remove tokens and expiry time
     this._accessToken = '';
     this._idToken = '';
@@ -96,7 +94,7 @@ export class AuthService {
   public isAuthenticated(): boolean {
     // Check whether the current time is past the
     // access token's expiry time
-    return new Date().getTime() < this._expiresAt;
+    return this._accessToken && Date.now() < this._expiresAt;
   }
 
   public renewTokens() {


### PR DESCRIPTION
- Instead of storing a flag on the localstorage, use a method that checks for variable in-memory value presence. 
- Replace usage of `new Date().getTime()` with `Date.now()`.