### PR TITLE
Refactored FontAwesome usage to be implicit, fixing unit tests

### DIFF
--- a/01-Login/src/app/app.module.ts
+++ b/01-Login/src/app/app.module.ts
@@ -4,6 +4,8 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { HighlightModule } from 'ngx-highlightjs';
 import json from 'highlight.js/lib/languages/json';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { faUser, faLink, faPowerOff } from '@fortawesome/free-solid-svg-icons';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -44,4 +46,10 @@ export function hljsLanguages() {
   providers: [],
   bootstrap: [AppComponent]
 })
-export class AppModule {}
+export class AppModule {
+  constructor() {
+    library.add(faUser);
+    library.add(faPowerOff);
+    library.add(faLink);
+  }
+}

--- a/01-Login/src/app/components/home-content/home-content.component.html
+++ b/01-Login/src/app/components/home-content/home-content.component.html
@@ -5,7 +5,7 @@
     <div class="col-md-5 mb-4">
       <h6 class="mb-3">
         <a href="https://auth0.com/docs/connections">
-          <fa-icon [icon]="faLink"></fa-icon> Configure other identity providers
+          <fa-icon icon="link"></fa-icon> Configure other identity providers
         </a>
       </h6>
       <p>
@@ -20,7 +20,7 @@
     <div class="col-md-5 mb-4">
       <h6 class="mb-3">
         <a href="https://auth0.com/docs/multifactor-authentication">
-          <fa-icon [icon]="faLink"></fa-icon> Enable Multifactor Authentication
+          <fa-icon icon="link"></fa-icon> Enable Multifactor Authentication
         </a>
       </h6>
       <p>
@@ -36,7 +36,7 @@
     <div class="col-md-5 mb-4">
       <h6 class="mb-3">
         <a href="https://auth0.com/docs/anomaly-detection">
-          <fa-icon [icon]="faLink"></fa-icon> Anomaly Detection
+          <fa-icon icon="link"></fa-icon> Anomaly Detection
         </a>
       </h6>
       <p>
@@ -51,7 +51,7 @@
     <div class="col-md-5 mb-4">
       <h6 class="mb-3">
         <a href="https://auth0.com/docs/rules">
-          <fa-icon [icon]="faLink"></fa-icon> Learn About Rules
+          <fa-icon icon="link"></fa-icon> Learn About Rules
         </a>
       </h6>
       <p>

--- a/01-Login/src/app/components/home-content/home-content.component.ts
+++ b/01-Login/src/app/components/home-content/home-content.component.ts
@@ -1,15 +1,8 @@
 import { Component, OnInit } from '@angular/core';
-import { faLink } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
   selector: 'app-home-content',
   templateUrl: './home-content.component.html',
   styleUrls: ['./home-content.component.css']
 })
-export class HomeContentComponent implements OnInit {
-  faLink = faLink;
-
-  constructor() {}
-
-  ngOnInit() {}
-}
+export class HomeContentComponent {}

--- a/01-Login/src/app/components/nav-bar/nav-bar.component.html
+++ b/01-Login/src/app/components/nav-bar/nav-bar.component.html
@@ -66,7 +66,7 @@
                 class="dropdown-item dropdown-profile"
                 *ngIf="profile"
               >
-                <fa-icon [icon]="faUser" class="mr-3"></fa-icon> Profile
+                <fa-icon icon="user" class="mr-3"></fa-icon> Profile
               </a>
               <button
                 href="#"
@@ -74,7 +74,7 @@
                 class="btn btn-link dropdown-item"
                 id="qsLogoutBtn"
               >
-                <fa-icon [icon]="faPowerOff" class="mr-3"></fa-icon> Log out
+                <fa-icon icon="power-off" class="mr-3"></fa-icon> Log out
               </button>
             </div>
           </li>
@@ -113,12 +113,12 @@
             </span>
           </li>
           <li>
-            <fa-icon [icon]="faUser" class="mr-3"></fa-icon>
+            <fa-icon icon="user" class="mr-3"></fa-icon>
             <a [routerLink]="['/profile']">Profile</a>
           </li>
 
           <li>
-            <fa-icon [icon]="faPowerOff" class="mr-3"></fa-icon>
+            <fa-icon icon="power-off" class="mr-3"></fa-icon>
             <button
               class="btn btn-link p-0"
               id="qsLogoutBtn"

--- a/01-Login/src/app/components/nav-bar/nav-bar.component.spec.ts
+++ b/01-Login/src/app/components/nav-bar/nav-bar.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
 import { NavBarComponent } from './nav-bar.component';
 
@@ -11,7 +12,7 @@ describe('NavBarComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [NavBarComponent],
-      imports: [NgbModule, RouterTestingModule]
+      imports: [NgbModule, RouterTestingModule, FontAwesomeModule]
     }).compileComponents();
   }));
 

--- a/02-Calling-an-API/src/app/app.module.ts
+++ b/02-Calling-an-API/src/app/app.module.ts
@@ -5,6 +5,8 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { HighlightModule } from 'ngx-highlightjs';
 import json from 'highlight.js/lib/languages/json';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { faUser, faLink, faPowerOff } from '@fortawesome/free-solid-svg-icons';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -48,4 +50,10 @@ export function hljsLanguages() {
   providers: [],
   bootstrap: [AppComponent]
 })
-export class AppModule {}
+export class AppModule {
+  constructor() {
+    library.add(faUser);
+    library.add(faPowerOff);
+    library.add(faLink);
+  }
+}

--- a/02-Calling-an-API/src/app/components/home-content/home-content.component.html
+++ b/02-Calling-an-API/src/app/components/home-content/home-content.component.html
@@ -5,7 +5,7 @@
     <div class="col-md-5 mb-4">
       <h6 class="mb-3">
         <a href="https://auth0.com/docs/connections">
-          <fa-icon [icon]="faLink"></fa-icon> Configure other identity providers
+          <fa-icon icon="link"></fa-icon> Configure other identity providers
         </a>
       </h6>
       <p>
@@ -20,7 +20,7 @@
     <div class="col-md-5 mb-4">
       <h6 class="mb-3">
         <a href="https://auth0.com/docs/multifactor-authentication">
-          <fa-icon [icon]="faLink"></fa-icon> Enable Multifactor Authentication
+          <fa-icon icon="link"></fa-icon> Enable Multifactor Authentication
         </a>
       </h6>
       <p>
@@ -36,7 +36,7 @@
     <div class="col-md-5 mb-4">
       <h6 class="mb-3">
         <a href="https://auth0.com/docs/anomaly-detection">
-          <fa-icon [icon]="faLink"></fa-icon> Anomaly Detection
+          <fa-icon icon="link"></fa-icon> Anomaly Detection
         </a>
       </h6>
       <p>
@@ -51,7 +51,7 @@
     <div class="col-md-5 mb-4">
       <h6 class="mb-3">
         <a href="https://auth0.com/docs/rules">
-          <fa-icon [icon]="faLink"></fa-icon> Learn About Rules
+          <fa-icon icon="link"></fa-icon> Learn About Rules
         </a>
       </h6>
       <p>

--- a/02-Calling-an-API/src/app/components/home-content/home-content.component.ts
+++ b/02-Calling-an-API/src/app/components/home-content/home-content.component.ts
@@ -1,15 +1,8 @@
 import { Component, OnInit } from '@angular/core';
-import { faLink } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
   selector: 'app-home-content',
   templateUrl: './home-content.component.html',
   styleUrls: ['./home-content.component.css']
 })
-export class HomeContentComponent implements OnInit {
-  faLink = faLink;
-
-  constructor() {}
-
-  ngOnInit() {}
-}
+export class HomeContentComponent {}

--- a/02-Calling-an-API/src/app/components/nav-bar/nav-bar.component.html
+++ b/02-Calling-an-API/src/app/components/nav-bar/nav-bar.component.html
@@ -69,7 +69,7 @@
                 class="dropdown-item dropdown-profile"
                 *ngIf="profile"
               >
-                <fa-icon [icon]="faUser" class="mr-3"></fa-icon> Profile
+                <fa-icon icon="user" class="mr-3"></fa-icon> Profile
               </a>
               <button
                 href="#"
@@ -77,7 +77,7 @@
                 class="btn btn-link dropdown-item"
                 id="qsLogoutBtn"
               >
-                <fa-icon [icon]="faPowerOff" class="mr-3"></fa-icon> Log out
+                <fa-icon icon="power-off" class="mr-3"></fa-icon> Log out
               </button>
             </div>
           </li>
@@ -116,12 +116,12 @@
             </span>
           </li>
           <li>
-            <fa-icon [icon]="faUser" class="mr-3"></fa-icon>
+            <fa-icon icon="user" class="mr-3"></fa-icon>
             <a [routerLink]="['/profile']">Profile</a>
           </li>
 
           <li>
-            <fa-icon [icon]="faPowerOff" class="mr-3"></fa-icon>
+            <fa-icon icon="power-off" class="mr-3"></fa-icon>
             <button
               class="btn btn-link p-0"
               id="qsLogoutBtn"

--- a/02-Calling-an-API/src/app/components/nav-bar/nav-bar.component.spec.ts
+++ b/02-Calling-an-API/src/app/components/nav-bar/nav-bar.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
 import { NavBarComponent } from './nav-bar.component';
 
@@ -11,7 +12,7 @@ describe('NavBarComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [NavBarComponent],
-      imports: [NgbModule, RouterTestingModule]
+      imports: [NgbModule, RouterTestingModule, FontAwesomeModule]
     }).compileComponents();
   }));
 


### PR DESCRIPTION
Adding the `FontAwesomeModule` to the nav bar component spec fixes the tests. However, took the time to refactor the icons to use the [implicit reference rather than explicit](﻿﻿﻿https://www.npmjs.com/package/@fortawesome/angular-fontawesome#usage).