### PR TITLE
Copy build output to login-demo directory expected by npm server

### DIFF
--- a/02-Calling-an-API/Dockerfile
+++ b/02-Calling-an-API/Dockerfile
@@ -26,7 +26,7 @@ COPY package.json .
 
 RUN npm install --production
 
-COPY --from=build ./app/dist/login-demo ./dist
+COPY --from=build ./app/dist/login-demo ./dist/login-demo/
 COPY ./server.js .
 COPY ./auth_config.json .
 


### PR DESCRIPTION
Hello, see issue #179 

I did some digging and found that the `COPY` was copying the files into `./dist/` and was not creating a `./dist/login-demo`.  For example, after a docker build, the index.html was available at `./dist/index.html` but the server was trying to serve it from `./dist/login-demo/index.html`, hence the 404.


This fix will allow the Docker instructions in the README for sample 02 to work as expected.  After applying, localhost:3000 started serving the sample app to me as expected.