### PR TITLE
Fix broken redirects

### DIFF
--- a/01-Login/src/app/auth/auth.service.ts
+++ b/01-Login/src/app/auth/auth.service.ts
@@ -108,7 +108,7 @@ export class AuthService {
       // Response will be an array of user and login status
       authComplete$.subscribe(([user, loggedIn]) => {
         // Redirect to target route after callback processing
-        this.router.navigate([targetRoute]);
+        this.router.navigateByUrl(targetRoute);
       });
     }
   }


### PR DESCRIPTION
When the target contains route parameters and we use the `navigate` method of the Angular router the route parameters get encoded which will result in an invalid url. We should use `navigateByUrl` here instead.