### PR TITLE
fixed auth redirects

### DIFF
--- a/01-Login/src/app/auth/auth.guard.ts
+++ b/01-Login/src/app/auth/auth.guard.ts
@@ -7,7 +7,7 @@ import {
 } from '@angular/router';
 import { Observable } from 'rxjs';
 import { AuthService } from './auth.service';
-import { tap } from 'rxjs/operators';
+import { skipWhile, switchMap, tap } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root'
@@ -20,13 +20,14 @@ export class AuthGuard implements CanActivate {
     next: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): Observable<boolean> | Promise<boolean|UrlTree> | boolean {
-    return this.auth.isAuthenticated$.pipe(
+    return this.auth.isAuthInProgress$.pipe(
+      skipWhile((inProgress: boolean) => inProgress),
+      switchMap(inProgress => this.auth.isAuthenticated$),
       tap(loggedIn => {
         if (!loggedIn) {
           this.auth.login(state.url);
         }
-      })
-    );
+      }));
   }
 
 }

--- a/01-Login/src/app/auth/auth.service.ts
+++ b/01-Login/src/app/auth/auth.service.ts
@@ -35,6 +35,9 @@ export class AuthService {
   // Create subject and public observable of user profile data
   private userProfileSubject$ = new BehaviorSubject<any>(null);
   userProfile$ = this.userProfileSubject$.asObservable();
+
+  isAuthInProgress$ = new BehaviorSubject<boolean>(false);
+
   // Create a local property for login status
   loggedIn: boolean = null;
 
@@ -89,6 +92,8 @@ export class AuthService {
     // Call when app reloads after user logs in with Auth0
     const params = window.location.search;
     if (params.includes('code=') && params.includes('state=')) {
+      this.isAuthInProgress$.next(true);
+
       let targetRoute: string; // Path to redirect to after login processsed
       const authComplete$ = this.handleRedirectCallback$.pipe(
         // Have client, now call method to handle auth callback redirect
@@ -107,6 +112,8 @@ export class AuthService {
       // Subscribe to authentication completion observable
       // Response will be an array of user and login status
       authComplete$.subscribe(([user, loggedIn]) => {
+        this.isAuthInProgress$.next(false);
+
         // Redirect to target route after callback processing
         this.router.navigateByUrl(targetRoute);
       });

--- a/02-Calling-an-API/src/app/auth/auth.guard.ts
+++ b/02-Calling-an-API/src/app/auth/auth.guard.ts
@@ -7,7 +7,7 @@ import {
 } from '@angular/router';
 import { Observable } from 'rxjs';
 import { AuthService } from './auth.service';
-import { tap } from 'rxjs/operators';
+import { skipWhile, switchMap, tap } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root'
@@ -20,13 +20,14 @@ export class AuthGuard implements CanActivate {
     next: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): Observable<boolean> | Promise<boolean|UrlTree> | boolean {
-    return this.auth.isAuthenticated$.pipe(
+    return this.auth.isAuthInProgress$.pipe(
+      skipWhile((inProgress: boolean) => inProgress),
+      switchMap(inProgress => this.auth.isAuthenticated$),
       tap(loggedIn => {
         if (!loggedIn) {
           this.auth.login(state.url);
         }
-      })
-    );
+      }));
   }
 
 }

--- a/02-Calling-an-API/src/app/auth/auth.service.ts
+++ b/02-Calling-an-API/src/app/auth/auth.service.ts
@@ -36,6 +36,9 @@ export class AuthService {
   // Create subject and public observable of user profile data
   private userProfileSubject$ = new BehaviorSubject<any>(null);
   userProfile$ = this.userProfileSubject$.asObservable();
+
+  isAuthInProgress$ = new BehaviorSubject<boolean>(false);
+
   // Create a local property for login status
   loggedIn: boolean = null;
 
@@ -98,6 +101,8 @@ export class AuthService {
     // Call when app reloads after user logs in with Auth0
     const params = window.location.search;
     if (params.includes('code=') && params.includes('state=')) {
+      this.isAuthInProgress$.next(true);
+
       let targetRoute: string; // Path to redirect to after login processsed
       const authComplete$ = this.handleRedirectCallback$.pipe(
         // Have client, now call method to handle auth callback redirect
@@ -116,6 +121,8 @@ export class AuthService {
       // Subscribe to authentication completion observable
       // Response will be an array of user and login status
       authComplete$.subscribe(([user, loggedIn]) => {
+        this.isAuthInProgress$.next(false);
+
         // Redirect to target route after callback processing
         this.router.navigate([targetRoute]);
       });


### PR DESCRIPTION
While the post login redirect works in the example, it breaks as soon as all routes (including the one to the HomeComponent) are restricted by the AuthGuard. 
In this case you will always be redirected to "domain.com/" after logging in even if you opened the browser at "domain.com/profile".

I thought this might be useful since this example is also used in the [Auth0 Quickstart for Angular here](https://manage.auth0.com/dashboard/eu/oo-vouchers-local/applications/47ntxdQlfLAYG00bf65OHyoNDy4ckauW/quickstart).