### PR TITLE
Make sample more resilient when handling missing or default audience

### DIFF
--- a/Sample-01/api-server.js
+++ b/Sample-01/api-server.js
@@ -8,8 +8,16 @@ const authConfig = require('./auth_config.json');
 
 const app = express();
 
-if (!authConfig.domain || !authConfig.audience) {
-  throw 'Please make sure that auth_config.json is in place and populated';
+if (
+  !authConfig.domain ||
+  !authConfig.audience ||
+  authConfig.audience === "YOUR_API_IDENTIFIER"
+) {
+  console.log(
+    "Exiting: Please make sure that auth_config.json is in place and populated with valid domain and audience values"
+  );
+
+  process.exit();
 }
 
 app.use(morgan('dev'));

--- a/Sample-01/src/app/pages/external-api/external-api.component.html
+++ b/Sample-01/src/app/pages/external-api/external-api.component.html
@@ -1,12 +1,65 @@
 <div class="container mt-5">
   <h1>External API</h1>
+
+  <p class="lead">Ping an external API by clicking the button below.</p>
+
+  <p>
+    This will call a local API on port 3001 that would have been started if you
+    run <code>npm run dev</code> (or <code>npm run server:api</code>). An access token is sent as part of the
+    request's `Authorization` header and the API will validate it using the
+    API's audience value.
+  </p>
+
+  <ng-container *ngIf="!audience">
+    <div class="alert alert-warning" role="alert">
+      <p>
+        You can't call the API at the moment because your application does not
+        have any configuration for <code>audience</code>, or it is using the
+        default value of <code>YOUR_API_IDENTIFIER</code>. You might get this
+        default value if you used the "Download Sample" feature of
+        <a href="https://auth0.com/docs/quickstart/spa/angular">
+          the quickstart guide </a
+        >, but have not set an API up in your Auth0 Tenant. You can find out
+        more information on
+        <a href="https://auth0.com/docs/api">setting up APIs</a> in the Auth0
+        Docs.
+      </p>
+      <p>
+        The audience is the identifier of the API that you want to call (see
+        <a
+          href="https://auth0.com/docs/get-started/dashboard/tenant-settings#api-authorization-settings"
+        >
+          API Authorization Settings
+        </a>
+        for more info).
+      </p>
+
+      <p>
+        In this sample, you can configure the audience by specifying it in the
+        <code>auth_config.json</code> file (see the
+        <code>auth_config.json.example</code> file for an example of where it
+        should go)
+      </p>
+      <p>
+        Once you have configured the value for <code>audience</code>, please
+        restart the app and try to use the "Ping API" button below.
+      </p>
+    </div>
+  </ng-container>
+
   <p class="mb-5">
     Ping an external API by clicking the button below. This will call the
     external API using an access token, and the API will validate it using the
     API's audience value.
   </p>
 
-  <button class="btn btn-primary mb-5" (click)="pingApi()">Ping API</button>
+  <button
+    class="btn btn-primary mb-5"
+    [disabled]="!audience"
+    (click)="pingApi()"
+  >
+    Ping API
+  </button>
 
   <div class="result-block-container" *ngIf="responseJson">
     <div class="result-block" [ngClass]="{ show: !!responseJson }">

--- a/Sample-01/src/app/pages/external-api/external-api.component.ts
+++ b/Sample-01/src/app/pages/external-api/external-api.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
+import { AuthClientConfig } from '@auth0/auth0-angular';
 import { ApiService } from 'src/app/api.service';
 
 @Component({
@@ -8,8 +9,12 @@ import { ApiService } from 'src/app/api.service';
 })
 export class ExternalApiComponent {
   responseJson: string;
+  audience = this.configFactory.get()?.audience;
 
-  constructor(private api: ApiService) {}
+  constructor(
+    private api: ApiService,
+    private configFactory: AuthClientConfig
+  ) {}
 
   pingApi() {
     this.api

--- a/Sample-01/src/environments/environment.prod.ts
+++ b/Sample-01/src/environments/environment.prod.ts
@@ -1,11 +1,18 @@
-import { domain, clientId, audience, apiUri } from '../../auth_config.json';
+import config from '../../auth_config.json';
+
+const { domain, clientId, audience, apiUri } = config as {
+  domain: string;
+  clientId: string;
+  audience?: string;
+  apiUri: string;
+};
 
 export const environment = {
   production: true,
   auth: {
     domain,
     clientId,
-    audience,
+    ...(audience && audience !== "YOUR_API_IDENTIFIER" ? { audience } : null),
     redirectUri: window.location.origin,
   },
   httpInterceptor: {

--- a/Sample-01/src/environments/environment.ts
+++ b/Sample-01/src/environments/environment.ts
@@ -7,7 +7,7 @@ const { domain, clientId, audience, apiUri, errorPath } = config as {
   domain: string;
   clientId: string;
   audience?: string;
-  apiUri: string;;
+  apiUri: string;
   errorPath: string;
 };
 

--- a/Sample-01/src/environments/environment.ts
+++ b/Sample-01/src/environments/environment.ts
@@ -1,14 +1,21 @@
 // This file can be replaced during build by using the `fileReplacements` array.
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
-import { domain, clientId, audience, apiUri } from '../../auth_config.json';
+import config from '../../auth_config.json';
+
+const { domain, clientId, audience, apiUri } = config as {
+  domain: string;
+  clientId: string;
+  audience?: string;
+  apiUri: string;
+};
 
 export const environment = {
   production: false,
   auth: {
     domain,
     clientId,
-    audience,
+    ...(audience && audience !== 'YOUR_API_IDENTIFIER' ? { audience } : null),
     redirectUri: window.location.origin,
   },
   httpInterceptor: {


### PR DESCRIPTION
This PR attempts to make it work in more scenarios where the audience configuration value has not been specified or has been left at the default value of YOUR_API_IDENTIFIER (you might get this if you use the "download sample" tool on the quickstart but do not have any valid APIs set up in your tenant).

To do this:
- The API server gracefully exits if there's not a valid audience, with a warning message
- When Audience is missing or set to `YOUR_API_IDENTIFIER`, the sample disables the "Ping API" button and displays some help content (see below) to try and aid the developer in setting up the audience and what it means

**When no audience set:**
![image](https://user-images.githubusercontent.com/2146903/112442436-1be5ad80-8d4c-11eb-8b09-ef37e6225c61.png)

**When an audience is set:**
![image](https://user-images.githubusercontent.com/2146903/112442495-2dc75080-8d4c-11eb-9a7c-c4259debbe1d.png)

Closes #226