### PR TITLE
Improve error handling for the user

### DIFF
--- a/Sample-01/auth_config.json.example
+++ b/Sample-01/auth_config.json.example
@@ -3,5 +3,6 @@
   "clientId": "{CLIENT_ID}",
   "audience": "{API_IDENTIFIER}",
   "apiUri": "http://localhost:3001",
-  "appUri": "http://localhost:4200"
+  "appUri": "http://localhost:4200",
+  "errorPath": "/error"
 }

--- a/Sample-01/src/app/app-routing.module.ts
+++ b/Sample-01/src/app/app-routing.module.ts
@@ -3,6 +3,7 @@ import { Routes, RouterModule } from '@angular/router';
 import { HomeComponent } from './pages/home/home.component';
 import { ProfileComponent } from './pages/profile/profile.component';
 import { ExternalApiComponent } from './pages/external-api/external-api.component';
+import { ErrorComponent } from './pages/error/error.component';
 import { AuthGuard } from '@auth0/auth0-angular';
 
 const routes: Routes = [
@@ -15,6 +16,10 @@ const routes: Routes = [
     path: 'external-api',
     component: ExternalApiComponent,
     canActivate: [AuthGuard],
+  },
+  {
+    path: 'error',
+    component: ErrorComponent,
   },
   {
     path: '',

--- a/Sample-01/src/app/app.module.ts
+++ b/Sample-01/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { HomeComponent } from './pages/home/home.component';
 import { ProfileComponent } from './pages/profile/profile.component';
+import { ErrorComponent } from './pages/error/error.component';
 import { NavBarComponent } from './components/nav-bar/nav-bar.component';
 import { FooterComponent } from './components/footer/footer.component';
 import { HeroComponent } from './components/hero/hero.component';
@@ -30,6 +31,7 @@ import { environment as env } from '../environments/environment';
     HomeContentComponent,
     LoadingComponent,
     ExternalApiComponent,
+    ErrorComponent
   ],
   imports: [
     BrowserModule,

--- a/Sample-01/src/app/pages/error/error.component.html
+++ b/Sample-01/src/app/pages/error/error.component.html
@@ -1,0 +1,9 @@
+<div class="container mt-5">
+<ng-container *ngIf="error$ | async as error">
+  <h1>An error was returned from Auth0</h1>
+  <p>Something went wrong when trying to authorize your application. Please inspect the error below and ensure <code>auth_config.json</code> is configured correctly.</p>
+  <div class="alert alert-danger" role="alert">
+    {{error.error_description}}
+  </div>
+</ng-container>
+</div>

--- a/Sample-01/src/app/pages/error/error.component.ts
+++ b/Sample-01/src/app/pages/error/error.component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { AuthService } from '@auth0/auth0-angular';
+import { Observable, timer } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-error',
+  templateUrl: './error.component.html',
+})
+export class ErrorComponent {
+
+  public error$: Observable<any> = this.auth.error$;
+
+  constructor(private auth: AuthService, private router: Router) {}
+
+  ngOnInit() {
+    timer(0).pipe(takeUntil(this.error$)).subscribe(() => {
+      this.router.navigateByUrl('/');
+    });
+  }
+}
+

--- a/Sample-01/src/app/pages/external-api/external-api.component.html
+++ b/Sample-01/src/app/pages/external-api/external-api.component.html
@@ -1,5 +1,10 @@
 <div class="container mt-5">
   <h1>External API</h1>
+  <div *ngIf="hasApiError" class="alert alert-danger" role="alert">
+    An error occured when trying to call the local API on port 3001. Ensure the local API is started using either `npm run dev` or `npm run
+    server:api`.
+  </div>
+
   <p class="mb-5">
     Ping an external API by clicking the button below. This will call the
     external API using an access token, and the API will validate it using the

--- a/Sample-01/src/app/pages/external-api/external-api.component.ts
+++ b/Sample-01/src/app/pages/external-api/external-api.component.ts
@@ -8,14 +8,17 @@ import { ApiService } from 'src/app/api.service';
 })
 export class ExternalApiComponent {
   responseJson: string;
+  hasApiError = false;
 
   constructor(private api: ApiService) {}
 
   pingApi() {
-    this.api
-      .ping$()
-      .subscribe(
-        (res) => (this.responseJson = JSON.stringify(res, null, 2).trim())
-      );
+    this.api.ping$().subscribe({
+      next: (res) => {
+        this.hasApiError = false;
+        this.responseJson = JSON.stringify(res, null, 2).trim();
+      },
+      error: () => this.hasApiError = true,
+    });
   }
 }

--- a/Sample-01/src/environments/environment.prod.ts
+++ b/Sample-01/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
-import { domain, clientId, audience, apiUri } from '../../auth_config.json';
+import { domain, clientId, audience, apiUri, errorPath } from '../../auth_config.json';
 
 export const environment = {
   production: true,
@@ -7,6 +7,7 @@ export const environment = {
     clientId,
     audience,
     redirectUri: window.location.origin,
+    errorPath,
   },
   httpInterceptor: {
     allowedList: [`${apiUri}/*`],

--- a/Sample-01/src/environments/environment.ts
+++ b/Sample-01/src/environments/environment.ts
@@ -1,7 +1,7 @@
 // This file can be replaced during build by using the `fileReplacements` array.
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
-import { domain, clientId, audience, apiUri } from '../../auth_config.json';
+import { domain, clientId, audience, apiUri, errorPath } from '../../auth_config.json';
 
 export const environment = {
   production: false,
@@ -10,6 +10,7 @@ export const environment = {
     clientId,
     audience,
     redirectUri: window.location.origin,
+    errorPath,
   },
   httpInterceptor: {
     allowedList: [`${apiUri}/*`],


### PR DESCRIPTION
This PR improves error handling in two areas:

- `/authorize` errors that are sent back to the redirect_uri (e.g. Audience misconfiguration errors)
![image](https://user-images.githubusercontent.com/2146903/112454689-3eca8e80-8d59-11eb-92de-6c72b7944efb.png)
- API errors (mostly API not running)
![image](https://user-images.githubusercontent.com/2146903/112454867-6c173c80-8d59-11eb-8657-c1d6f47e4df1.png)

Closes #227
