### PR TITLE
Downgrade fontawesome

### DIFF
--- a/Sample-01/package-lock.json
+++ b/Sample-01/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser-dynamic": "^11.2.14",
         "@angular/router": "^11.2.14",
         "@auth0/auth0-angular": "^1.9.0",
-        "@fortawesome/angular-fontawesome": "~0.10.2",
+        "@fortawesome/angular-fontawesome": "~0.8.2",
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
         "@fortawesome/free-solid-svg-icons": "^5.15.4",
         "cors": "^2.8.5",
@@ -3067,14 +3067,15 @@
       }
     },
     "node_modules/@fortawesome/angular-fontawesome": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/angular-fontawesome/-/angular-fontawesome-0.10.2.tgz",
-      "integrity": "sha512-VxsCAo2lK74KwD236AKAhGpiethfz9yqCViIG2iRAZqgNmuZ6ihwumjbLW32n6hV4fFvCqLcHmpngoEl3TNiOg==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/angular-fontawesome/-/angular-fontawesome-0.8.2.tgz",
+      "integrity": "sha512-K/AiykA4YbHKE6XKEtZ0ZvVRQocUHyk+79HYWIfhGy3teHpzxsUqB/UjDaxivgBd6dF6ihlzgEbgrDMHlGNwGg==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.1.0"
       },
       "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~1.2.27 || ~1.3.0-beta2 || ^6.1.0"
+        "@angular/core": "^11.0.0",
+        "@fortawesome/fontawesome-svg-core": "^1.2.27"
       }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
@@ -23207,11 +23208,11 @@
       }
     },
     "@fortawesome/angular-fontawesome": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/angular-fontawesome/-/angular-fontawesome-0.10.2.tgz",
-      "integrity": "sha512-VxsCAo2lK74KwD236AKAhGpiethfz9yqCViIG2iRAZqgNmuZ6ihwumjbLW32n6hV4fFvCqLcHmpngoEl3TNiOg==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/angular-fontawesome/-/angular-fontawesome-0.8.2.tgz",
+      "integrity": "sha512-K/AiykA4YbHKE6XKEtZ0ZvVRQocUHyk+79HYWIfhGy3teHpzxsUqB/UjDaxivgBd6dF6ihlzgEbgrDMHlGNwGg==",
       "requires": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.1.0"
       }
     },
     "@fortawesome/fontawesome-common-types": {

--- a/Sample-01/package.json
+++ b/Sample-01/package.json
@@ -28,7 +28,7 @@
     "@angular/platform-browser-dynamic": "^11.2.14",
     "@angular/router": "^11.2.14",
     "@auth0/auth0-angular": "^1.9.0",
-    "@fortawesome/angular-fontawesome": "~0.10.2",
+    "@fortawesome/angular-fontawesome": "~0.8.2",
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "cors": "^2.8.5",


### PR DESCRIPTION
This PR downgrades Fontawesome for Angular, as the sample is using Angular 11 and the current version has been incorrectly updated as only 0.8.x works with Angular 11.

Also bumped our own SDK.