### PR TITLE
Group angular updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,12 @@ updates:
     directory: "/Sample-01" 
     schedule:
       interval: "daily"
+    groups:
+      angular:
+        patterns:
+          - "@angular*"
+        update-types:
+          - "minor"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-patch"]


### PR DESCRIPTION
Given that `@angular` updates need to be performed together, create a group that instructs dependabot to do this, [docs here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)