### PR TITLE
Update to latest browser-tools orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ version: 2.1
 orbs:
   node: circleci/node@5.1.0
   docker: circleci/docker@2.2.0
-  browser-tools: circleci/browser-tools@1.4.3
+  browser-tools: circleci/browser-tools@1.4.6
 
 jobs:
   checkout:


### PR DESCRIPTION
There were some further changes to browser-tools that are required, it seems that potentially the new version of chrome is exposing the issues these fixed

See auth0-samples/auth0-ionic-samples/pull/621