### PR TITLE
Updating default audience config values and logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This can be done by renaming `auth_config.json.example` (https://github.com/auth
   "domain": "YOUR_DOMAIN",
   "clientId": "YOUR_CLIENT_ID",
   "authorizationParams": {
-    "audience": "YOUR_API_IDENTIFIER",
+    "audience": "{yourApiIdentifier}",
   },
   "apiUri": "http://localhost:3001",
   "appUri": "http://localhost:4200"

--- a/Sample-01/api-server.js
+++ b/Sample-01/api-server.js
@@ -10,10 +10,12 @@ const app = express();
 if (
   !authConfig.domain ||
   !authConfig.authorizationParams.audience ||
-  ["YOUR_API_IDENTIFIER", "{API_IDENTIFIER}"].includes(authConfig.authorizationParams.audience)
+  ['{yourApiIdentifier}', '{API_IDENTIFIER}'].includes(
+    authConfig.authorizationParams.audience
+  )
 ) {
   console.log(
-    "Exiting: Please make sure that auth_config.json is in place and populated with valid domain and audience values"
+    'Exiting: Please make sure that auth_config.json is in place and populated with valid domain and audience values'
   );
 
   process.exit();

--- a/Sample-01/src/app/pages/external-api/external-api.component.html
+++ b/Sample-01/src/app/pages/external-api/external-api.component.html
@@ -1,6 +1,6 @@
 <div class="container mt-5">
   <h1>External API</h1>
-  
+
   <div *ngIf="hasApiError" class="alert alert-danger" role="alert">
     An error occured when trying to call the local API on port 3001. Ensure the local API is started using either `npm run dev` or `npm run
     server:api`.
@@ -20,7 +20,7 @@
       <p>
         You can't call the API at the moment because your application does not
         have any configuration for <code>audience</code>, or it is using the
-        default value of <code>YOUR_API_IDENTIFIER</code>. You might get this
+        default value of <code>&#123;yourApiIdentifier&#125;</code>. You might get this
         default value if you used the "Download Sample" feature of
         <a href="https://auth0.com/docs/quickstart/spa/angular">
           the quickstart guide </a

--- a/Sample-01/src/environments/environment.prod.ts
+++ b/Sample-01/src/environments/environment.prod.ts
@@ -13,7 +13,7 @@ export const environment = {
   auth: {
     domain,
     clientId,
-    ...(audience && audience !== "YOUR_API_IDENTIFIER" ? { audience } : null),
+    ...(audience && audience !== "{yourApiIdentifier}" ? { audience } : null),
     redirectUri: window.location.origin,
     errorPath,
   },

--- a/Sample-01/src/environments/environment.ts
+++ b/Sample-01/src/environments/environment.ts
@@ -19,7 +19,7 @@ export const environment = {
     domain,
     clientId,
     authorizationParams: {
-      ...(audience && audience !== 'YOUR_API_IDENTIFIER' ? { audience } : null),
+      ...(audience && audience !== '{yourApiIdentifier}' ? { audience } : null),
       redirect_uri: window.location.origin,
     },
     errorPath,

--- a/Standalone/api-server.js
+++ b/Standalone/api-server.js
@@ -10,10 +10,12 @@ const app = express();
 if (
   !authConfig.domain ||
   !authConfig.authorizationParams.audience ||
-  ["YOUR_API_IDENTIFIER", "{API_IDENTIFIER}"].includes(authConfig.authorizationParams.audience)
+  ['{yourApiIdentifier}', '{API_IDENTIFIER}'].includes(
+    authConfig.authorizationParams.audience
+  )
 ) {
   console.log(
-    "Exiting: Please make sure that auth_config.json is in place and populated with valid domain and audience values"
+    'Exiting: Please make sure that auth_config.json is in place and populated with valid domain and audience values'
   );
 
   process.exit();

--- a/Standalone/src/app/pages/external-api/external-api.component.html
+++ b/Standalone/src/app/pages/external-api/external-api.component.html
@@ -1,6 +1,6 @@
 <div class="container mt-5">
   <h1>External API</h1>
-  
+
   <div *ngIf="hasApiError" class="alert alert-danger" role="alert">
     An error occured when trying to call the local API on port 3001. Ensure the local API is started using either `npm run dev` or `npm run
     server:api`.
@@ -20,7 +20,7 @@
       <p>
         You can't call the API at the moment because your application does not
         have any configuration for <code>audience</code>, or it is using the
-        default value of <code>YOUR_API_IDENTIFIER</code>. You might get this
+        default value of <code>&#123;yourApiIdentifier&#125;</code>. You might get this
         default value if you used the "Download Sample" feature of
         <a href="https://auth0.com/docs/quickstart/spa/angular">
           the quickstart guide </a

--- a/Standalone/src/environments/environment.prod.ts
+++ b/Standalone/src/environments/environment.prod.ts
@@ -13,7 +13,7 @@ export const environment = {
   auth: {
     domain,
     clientId,
-    ...(audience && audience !== "YOUR_API_IDENTIFIER" ? { audience } : null),
+    ...(audience && audience !== "{yourApiIdentifier}" ? { audience } : null),
     redirectUri: window.location.origin,
     errorPath,
   },

--- a/Standalone/src/environments/environment.ts
+++ b/Standalone/src/environments/environment.ts
@@ -19,7 +19,7 @@ export const environment = {
     domain,
     clientId,
     authorizationParams: {
-      ...(audience && audience !== 'YOUR_API_IDENTIFIER' ? { audience } : null),
+      ...(audience && audience !== '{yourApiIdentifier}' ? { audience } : null),
       redirect_uri: window.location.origin,
     },
     errorPath,


### PR DESCRIPTION
### Changes
- Replaced all usage of  `"YOUR_API_IDENTIFIER"` -> `"{yourApiIdentifier}"`. Currently, if a user downloads the Auth0 Angular sample app without an API, the downloaded sample app has its `audience` value in auth_config.json set to 
`"{yourApiIdentifier}"`. This is because `"YOUR_API_IDENTIFIER"` is no longer the default value, as it has been swapped with `"{yourApiIdentifier}"`.

### Supporting References
- https://github.com/auth0-samples/auth0-angular-samples/issues/466
- https://github.com/auth0-samples/auth0-angular-samples/issues/226