### PR TITLE
Changing duplicate {yourApiIdentifier} value when downloaded as sample app

### DIFF
--- a/Sample-01/api-server.js
+++ b/Sample-01/api-server.js
@@ -10,9 +10,7 @@ const app = express();
 if (
   !authConfig.domain ||
   !authConfig.authorizationParams.audience ||
-  ["{yourApiIdentifier}", "{API_IDENTIFIER}"].includes(
-    authConfig.authorizationParams.audience
-  )
+  authConfig.authorizationParams.audience === '{API_IDENTIFIER}'
 ) {
   console.log(
     'Exiting: Please make sure that auth_config.json is in place and populated with valid domain and audience values'

--- a/Sample-01/api-server.js
+++ b/Sample-01/api-server.js
@@ -10,7 +10,7 @@ const app = express();
 if (
   !authConfig.domain ||
   !authConfig.authorizationParams.audience ||
-  ['{yourApiIdentifier}', '{API_IDENTIFIER}'].includes(
+  ["{yourApiIdentifier}", "{API_IDENTIFIER}"].includes(
     authConfig.authorizationParams.audience
   )
 ) {

--- a/Standalone/api-server.js
+++ b/Standalone/api-server.js
@@ -10,9 +10,7 @@ const app = express();
 if (
   !authConfig.domain ||
   !authConfig.authorizationParams.audience ||
-  ['{yourApiIdentifier}', '{API_IDENTIFIER}'].includes(
-    authConfig.authorizationParams.audience
-  )
+  authConfig.authorizationParams.audience === '{API_IDENTIFIER}'
 ) {
   console.log(
     'Exiting: Please make sure that auth_config.json is in place and populated with valid domain and audience values'


### PR DESCRIPTION
### Background
Currently, this line in api-server.js is:
```
 ['{yourApiIdentifier}', '{API_IDENTIFIER}'].includes(
    authConfig.authorizationParams.audience
  )
```

But when the Angular sample app is downloaded from the Quickstarts (both Dashboard and from auth0.com/docs) and the user does not have an API created, this line in api-server.js becomes: 
```
['{yourApiIdentifier}', '{yourApiIdentifier}'].includes(
    authConfig.authorizationParams.audience
```

This is because `'{API_IDENTIFIER}'` is being replaced with `'{yourApiIdentifier}'` when downloaded as a sample app. 
**Note:** this was happening even prior to the changes made in https://github.com/auth0-samples/auth0-angular-samples/pull/524, so that PR did not create this text replacing.

### Changes
In this PR, we changed `['{yourApiIdentifier}', '{API_IDENTIFIER}']` to `authConfig.authorizationParams.audience === '{API_IDENTIFIER}'` to remove this duplicated string from happening. This way, it still satisfies both use cases: 

- `'{API_IDENTIFIER}'` is used when a user downloads the sample app straight from Github
- `'{yourApiIdentifier}'` is used when a user downloads the sample app from a Quickstart
